### PR TITLE
カードの下部がベースラインに揃うよう修正

### DIFF
--- a/components/ProjectCardCampfire.vue
+++ b/components/ProjectCardCampfire.vue
@@ -6,7 +6,7 @@
     <p class="subtitle is-6">
       {{ caption }}
     </p>
-    <iframe frameborder="0" height="365" scrolling="no" :src="projectUrl" width="245" class="card-content lazyload"></iframe>
+    <iframe frameborder="0" height="365" scrolling="no" :src="projectUrl" width="245" class="iframe-card-content lazyload"></iframe>
   </div>
 </template>
 
@@ -45,7 +45,7 @@ export default {
   align-items: center;
 }
 
-.card-content {
+.iframe-card-content {
   margin-top: auto;
 }
 </style>

--- a/components/ProjectCardCampfire.vue
+++ b/components/ProjectCardCampfire.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="column is-3 has-padding-30">
+  <div class="column is-3 has-padding-30 is-aligned">
     <p class="title is-5 is-spaced">
       {{ title }}
     </p>
     <p class="subtitle is-6">
       {{ caption }}
     </p>
-    <iframe frameborder="0" height="365" scrolling="no" :src="projectUrl" width="245" class="lazyload"></iframe>
+    <iframe frameborder="0" height="365" scrolling="no" :src="projectUrl" width="245" class="card-content lazyload"></iframe>
   </div>
 </template>
 
@@ -37,5 +37,15 @@ export default {
 <style>
 .has-padding-30 {
   padding: 30px !important;
+}
+
+.is-aligned {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card-content {
+  margin-top: auto;
 }
 </style>


### PR DESCRIPTION
## BEFORE
- カードの下部が揃っていない

## AFTER
- カードの下部が揃っている
    - CSSを追加し、カード上部にマージンをとるよう修正した

## スクリーンショット
|BEFORE|AFTER|
|:---:|:---:|
|<img src=https://user-images.githubusercontent.com/28388130/81034230-6c081700-8ed1-11ea-9523-d2e22dd975b4.png  width=75%> | <img src=https://user-images.githubusercontent.com/28388130/81034294-a07bd300-8ed1-11ea-93d8-77a2f492c5ce.png  width=75%> |

## このPRで扱っていないこと
📁 ` /components/ProjectCardMotiongallery.vue` で描写されているカードに関しては要素の高さが可変になるため、ここでは扱っておりません。

## ひとこと
- いわさきさんお久しぶりです！素敵なアプリですね :)
陰ながら応援しておりますー！